### PR TITLE
workaround jimp/utifs library where it attempts to use window object …

### DIFF
--- a/source/main/ingest/image/states/run-imageinfo/imageProcess.js
+++ b/source/main/ingest/image/states/run-imageinfo/imageProcess.js
@@ -26,9 +26,12 @@ const MAX_IMAGE_SIZE = 5 * 1000 * 1000;
 const MAX_THUMBNAIL_WIDTH = 480;
 const MAX_THUMBNAIL_HEIGHT = 270;
 
+const TIFF_EXTENSIONS = ['.tif', '.tiff'];
+
 class ImageProcess {
   constructor(stateData) {
     this.$stateData = stateData;
+    _workaroundTIFFCMYKColorFormat(stateData);
   }
 
   get [Symbol.toStringTag]() {
@@ -241,6 +244,25 @@ class ImageProcess {
 
   async createProxy() {
     return undefined;
+  }
+}
+
+// WORKAROUND:
+// TIFF decoder package looks for "window" object when color space is CMYK
+// @jimp/node_modules/utif2/utif.js#1415
+function _workaroundTIFFCMYKColorFormat(data) {
+  const {
+    input: {
+      key,
+    },
+  } = data;
+
+  const ext = PATH.parse(key).ext.toLowerCase();
+
+  if (TIFF_EXTENSIONS.includes(ext)) {
+    if (global.window === undefined) {
+      global.window = {};
+    }
   }
 }
 


### PR DESCRIPTION
…(browser mode) in nodejs to decode TIFF CMYK color space image.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
