### PR TITLE
fix an issue when video contains very large portion of black frame se…

### DIFF
--- a/source/main/analysis/video/states/collect-results-iterator/iterators/collect-segment/index.js
+++ b/source/main/analysis/video/states/collect-results-iterator/iterators/collect-segment/index.js
@@ -480,17 +480,26 @@ async function _checkBlackFrames(
   prefix,
   candidates
 ) {
-  const minLaplacian = Math.min(
-    ...candidates
-      .map((x) =>
-        x.laplacian)
-  );
+  let qualified = candidates;
+
+  // entire shot are black frames?
+  let laplacians = candidates.map(({ laplacian }) => laplacian);
+  debugger;
+
+  laplacians = [...new Set(laplacians)];
+
+  if (laplacians.length === 1 && candidates.length > 2) {
+    candidates.sort((a, b) => a.frameIdx - b.frameIdx);
+    qualified = [candidates[0], candidates[candidates.length - 1]];
+  }
 
   const promises = [];
   const blackFrames = [];
 
-  for (let i = 0; i < candidates.length; i += 1) {
-    const candidate = candidates[i];
+  const minLaplacian = Math.min(...laplacians);
+
+  for (let i = 0; i < qualified.length; i += 1) {
+    const candidate = qualified[i];
 
     if (candidate.laplacian === minLaplacian) {
       promises.push(_analyseBlackLevel(


### PR DESCRIPTION
…gment (>15 minutes) that forces the lambda function to run black frame detection logic that causes the lambda function timeout in 15 minutes due to the small memory size of the lambda.

The new implementation is to minimize the number of the frame to be evaluated by checking the laplacian value at the shot level.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
